### PR TITLE
[SECURITY] Fix command injection vulnerability in setInitAction (Privilege Escalation)

### DIFF
--- a/root/usr/libexec/rpcd/luci.https-dns-proxy
+++ b/root/usr/libexec/rpcd/luci.https-dns-proxy
@@ -113,6 +113,17 @@ get_providers() {
 
 set_init_action() {
 	local name="$1" action="$2" cmd
+	
+	# SECURITY FIX: Validate name parameter to prevent command injection
+	# CVE-202X-XXXXX: Privilege Escalation via unsanitized 'name' parameter
+	# Fix by: Ahmet Mersin (ahmetmersin.com)
+	# Only allow the expected package name
+	if [ "$name" != "$packageName" ]; then
+		logger "SECURITY: Rejected invalid name parameter: $name"
+		print_json_bool "result" '0'
+		return 1
+	fi
+	
 	case $action in
 		enable|disable|start|stop|restart)
 			cmd="/etc/init.d/${name} ${action}"


### PR DESCRIPTION
## Summary
This PR fixes a **critical command injection vulnerability** in the `setInitAction` function that allows privilege escalation from a limited user to root.

## Vulnerability Details
- **Type**: Command Injection → Privilege Escalation
- **Affected Function**: `set_init_action()` in `luci.https-dns-proxy`
- **Root Cause**: The `name` parameter is passed unsanitized to `eval`
- **Impact**: A user with only `luci-app-https-dns-proxy` ACL can execute arbitrary commands as root

## Proof of Concept
A limited user can inject shell metacharacters via the `name` parameter:
```json
{"name": "x; id > /tmp/pwned; #", "action": "start"}
```

## Fix
Added validation to ensure the `name` parameter matches the expected package name (`https-dns-proxy`) before processing.

## Credit
Discovered and fixed by: Ahmet Mersin (ahmetmersin.com)

## Severity
**Critical** - Allows full system compromise from a limited user account.