### PR TITLE
update dns.sb bootstrap secondary IPv4 address

### DIFF
--- a/root/usr/share/https-dns-proxy/providers/sb.dns.json
+++ b/root/usr/share/https-dns-proxy/providers/sb.dns.json
@@ -1,7 +1,7 @@
 {
 	"title": "DoH DNS (SB)",
 	"template": "https://doh.dns.sb/dns-query",
-	"bootstrap_dns": "185.222.222.222,185.184.222.222",
+	"bootstrap_dns": "185.222.222.222,45.11.45.11",
 	"help_link": "https://dns.sb/doh/",
 	"http2_only": true
 }


### PR DESCRIPTION
Update the secondary bootstrap IPv4 address for dns.sb to its latest official value.
This ensures reliable resolution of the endpoints.

Changes:
- IPv4 Secondary: 185.184.222.222 -> 45.11.45.11 (Updated)

Source:
- Official Docs: https://dns.sb/guide/