### PR TITLE
Add IPv6 addresses to AdGuard DNS configuration

### DIFF
--- a/root/usr/share/https-dns-proxy/providers/com.adguard.dns.json
+++ b/root/usr/share/https-dns-proxy/providers/com.adguard.dns.json
@@ -1,7 +1,7 @@
 {
 	"title": "AdGuard",
 	"template": "https://{option}.adguard-dns.com/dns-query",
-	"bootstrap_dns": "94.140.14.140,94.140.14.141",
+	"bootstrap_dns": "94.140.14.140,94.140.14.141,2a10:50c0::1:ff,2a10:50c0::2:ff",
 	"help_link": "https://adguard-dns.io/en/public-dns.html",
 	"params": {
 		"option": {


### PR DESCRIPTION
Updated bootstrap DNS addresses to include IPv6 options.

Makefile is not bumped awaiting more enhancements