### PR TITLE
Add Quad9 Unsecured w/ ECS support provider

### DIFF
--- a/root/usr/share/https-dns-proxy/providers/net.quad9.json
+++ b/root/usr/share/https-dns-proxy/providers/net.quad9.json
@@ -24,6 +24,10 @@
 				{
 					"value": "dns11",
 					"description": "Secured with ECS Support"
+				},
+				{
+					"value": "dns12",
+					"description": "Unsecured with ECS Support"
 				}
 			],
 			"default": "dns"

--- a/root/usr/share/https-dns-proxy/providers/net.quad9.json
+++ b/root/usr/share/https-dns-proxy/providers/net.quad9.json
@@ -7,7 +7,7 @@
 		"option": {
 			"description": "Variant",
 			"type": "select",
-			"regex": "(dns|dns9|dns10|dns11)",
+			"regex": "(dns|dns9|dns10|dns11|dns12)",
 			"options": [
 				{
 					"value": "dns",


### PR DESCRIPTION
Just noticed it's missing, it's listed under https://docs.quad9.net/services/#99912-no-threat-blocking-ecs and also https://en.wikipedia.org/wiki/Quad9#Service